### PR TITLE
project like other pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,8 +25,6 @@
         <a class="page-link" href="{{ site.baseurl | prepend: site.url }}/">about</a>
 
         <a class="page-link" href="{{ site.ku_leuven_personnel_number | prepend: 'http://lirias.kuleuven.be/cv?Username=u' }}" target="_blank">publications</a>
-        <!-- Projects -->
-        <a class="page-link" href="{{ '/projects/' | prepend: site.baseurl | prepend: site.url }}">projects</a>
 
         <!-- Pages -->
         {% for page in site.pages %}

--- a/_pages/projects.html
+++ b/_pages/projects.html
@@ -1,11 +1,8 @@
 ---
-layout: default
+layout: page
+permalink: /projects/
+title: projects
 ---
-
-<div class="post-header">
-  <h1 class="post-title">projects</h1>
-</div>
-
 
 <ul class="post-list">
   {% for project in site.projects %}


### PR DESCRIPTION
For some reason, the project page was treated differently than the other pages. I changed it so that it is the same. This does not change any functionality, but it 1) simplifies the folder structure, 2) simplifies the projects.html file (previously projects/index.html), and 3) simplifies the header as it no longer needs to regard projects as a special page